### PR TITLE
🔧 fix: Update file path handling in crawler and asset loading

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -105,7 +105,7 @@ func quotesParse(g *geziyor.Geziyor, r *client.Response) {
 					g.Get(r.JoinURL(link), parseCSS)
 				}
 
-				newLink := "/" + netutil.Folders["css"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
+				newLink := netutil.Folders["css"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
 				body = strings.Replace(body, data, newLink, -1)
 			}
 		}
@@ -308,7 +308,16 @@ func quotesParse(g *geziyor.Geziyor, r *client.Response) {
 		files.pages = append(files.pages, urlPath)
 	}
 
-	index, err := fsutil.OpenFile(projectPath+urlPath+"/index.html", fsutil.FsCWFlags, 0o666)
+	// Fix the file path issue - handle empty urlPath properly
+	var filePath string
+	cleanURLPath := strings.TrimPrefix(urlPath, "/")
+	if cleanURLPath == "" {
+		filePath = filepath.Join(projectPath, "index.html")
+	} else {
+		filePath = filepath.Join(projectPath, cleanURLPath, "index.html")
+	}
+
+	index, err := fsutil.OpenFile(filePath, fsutil.FsCWFlags, 0o666)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/crawler/css.go
+++ b/pkg/crawler/css.go
@@ -19,7 +19,7 @@ func parseCSS(g *geziyor.Geziyor, r *client.Response) {
 	body := string(r.Body)
 	base := path.Base(r.Request.URL.Path)
 
-	index, err := fsutil.OpenFile(projectPath+"/assets/css/"+base, fsutil.FsCWFlags, 0o666)
+	index, err := fsutil.OpenFile(filepath.Join(projectPath, "assets/css", base), fsutil.FsCWFlags, 0o666)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/crawler/img.go
+++ b/pkg/crawler/img.go
@@ -18,7 +18,7 @@ func saveIMG(parsedURL *url.URL, body string) string {
 			go netutil.Extractor(link, projectPath)
 		}
 
-		newLink := "/" + netutil.Folders["img"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
+		newLink := netutil.Folders["img"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
 		return strings.Replace(body, link, newLink, -1)
 	}
 	return body

--- a/pkg/crawler/js.go
+++ b/pkg/crawler/js.go
@@ -18,7 +18,7 @@ func saveJS(parsedURL *url.URL, body string) string {
 			go netutil.Extractor(link, projectPath)
 		}
 
-		newLink := "/" + netutil.Folders["js"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
+		newLink := netutil.Folders["js"] + "/" + netutil.ReplaceSlashWithDash(parsedURL.Path)
 		return strings.Replace(body, link, newLink, -1)
 	}
 	return body

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -46,7 +46,7 @@ func Extractor(link, projectPath string) {
 	ext := urlExtension(resp.Request.URL.Path)
 
 	if ext != "" {
-		dirPath := "/" + Extensions[ext] + "/"
+		dirPath := Extensions[ext] + "/"
 		if dirPath != "" {
 			name := ReplaceSlashWithDash(resp.Request.URL.Path)
 
@@ -63,7 +63,7 @@ func Extractor(link, projectPath string) {
 
 // GetAssetDir is ...
 func GetAssetDir(filename string) string {
-	dirPath := "/" + Extensions[urlExtension(filename)] + "/"
+	dirPath := Extensions[urlExtension(filename)] + "/"
 	if dirPath != "" {
 		return dirPath
 	}


### PR DESCRIPTION
This pull request focuses on improving file path handling and standardizing path construction across the codebase. The changes primarily address issues with unnecessary leading slashes in paths and ensure proper handling of edge cases, such as empty paths. 

### File Path Handling Improvements:

* [`pkg/crawler/crawler.go`](diffhunk://#diff-526a7142f7b15a72eab215dcfa540f5b6d502951a2f9f3b34dd900013e82c675L108-R108): Fixed path construction by removing unnecessary leading slashes in `newLink` for CSS links and implemented logic to handle empty `urlPath` when constructing file paths for `index.html`. [[1]](diffhunk://#diff-526a7142f7b15a72eab215dcfa540f5b6d502951a2f9f3b34dd900013e82c675L108-R108) [[2]](diffhunk://#diff-526a7142f7b15a72eab215dcfa540f5b6d502951a2f9f3b34dd900013e82c675L311-R320)

* [`pkg/crawler/css.go`](diffhunk://#diff-44f20bf28c17520ba46bf89681caf4f9931e1645c35f9c0f6668c9bbd74df5d0L22-R22): Updated the file path construction in `parseCSS` to use `filepath.Join` for better cross-platform compatibility and readability.

* [`pkg/crawler/img.go`](diffhunk://#diff-3a60fb9ff67718f57fc66054ecf3f5822fc5238b9c08f96c91cc456f6f0039a9L21-R21): Removed the leading slash in `newLink` for image paths to standardize path formatting.

* [`pkg/crawler/js.go`](diffhunk://#diff-dcc4b4c2cfb3ff70e36a3de59f89518793306c4ffe7c2469ea12c8970debd8b0L21-R21): Standardized JavaScript file paths by removing the leading slash in `newLink`.

* [`pkg/netutil/netutil.go`](diffhunk://#diff-669913e187d4dc726dcb9e01a5666ae0562549545138d25d2c8fc2ceb3e23d30L49-R49): Updated `dirPath` construction in `Extractor` and `GetAssetDir` functions to remove unnecessary leading slashes, ensuring consistent path formatting. [[1]](diffhunk://#diff-669913e187d4dc726dcb9e01a5666ae0562549545138d25d2c8fc2ceb3e23d30L49-R49) [[2]](diffhunk://#diff-669913e187d4dc726dcb9e01a5666ae0562549545138d25d2c8fc2ceb3e23d30L66-R66)