### PR TITLE
fix(crawler): extract image assets inside <noscript> fallback blocks

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -247,6 +247,34 @@ func quotesParse(g *geziyor.Geziyor, r *client.Response) {
 		}
 	})
 
+	// <noscript> fallback content. Go's HTML parser keeps the contents of a
+	// <noscript> element as raw text (scripting is treated as enabled), so any
+	// <img>/<source> assets inside are invisible to the selectors above. Many
+	// sites (especially JS-rendered ones) place the real <img src> fallbacks
+	// there, so re-parse the inner HTML and extract those assets too.
+	r.HTMLDoc.Find("noscript").Each(func(i int, s *goquery.Selection) {
+		inner, err := goquery.NewDocumentFromReader(strings.NewReader(s.Text()))
+		if err != nil {
+			return
+		}
+		inner.Find("img[src],img[srcset],source[srcset]").Each(func(j int, im *goquery.Selection) {
+			if v, ok := im.Attr("srcset"); ok {
+				body = processSrcset(v, body, r.JoinURL)
+			}
+			if v, ok := im.Attr("src"); ok {
+				parsed, err := url.Parse(v)
+				if err != nil {
+					fmt.Println("Error parsing URL:", err)
+					return
+				}
+				if parsed.Scheme == "data" || parsed.Scheme == "blob" {
+					return
+				}
+				body = saveAsset("img", r.JoinURL(v), v, body)
+			}
+		})
+	})
+
 	// Inline CSS blocks
 	r.HTMLDoc.Find("style").Each(func(i int, s *goquery.Selection) {
 		data := s.Text()


### PR DESCRIPTION
## Problem

Images nested inside `<noscript>` fallback blocks are never downloaded.

Go's HTML parser (`golang.org/x/net/html`, used via goquery) keeps the
contents of a `<noscript>` element as **raw text** because scripting is
treated as enabled. As a result the existing
`img[src] / img[srcset] / picture source[srcset]` selectors in `quotesParse`
cannot see any `<img>`/`<source>` elements inside `<noscript>`.

JS-rendered sites very commonly put the real `<img src>` fallback there
(the visible image is injected by JS at runtime, and the `<noscript>` holds
the no-JS fallback pointing at the same asset). On such sites those images
are silently skipped.

### Reproduction

A webp-heavy, JS-rendered site whose homepage references its hero/section
images only via `<noscript><img src="..."></noscript>` (plus JS data
attributes). Cloning it downloaded **4** images while the pages referenced
dozens.

Confirmed root cause with goquery directly on the saved `index.html`:

```
img[src] matched: 4
noscript blocks: 9
img[src] inside noscript-as-html: 1   # reparsing one block's text reveals the hidden <img>
```

## Fix

After the existing `picture source[srcset]` handling, iterate every
`<noscript>` block, re-parse its inner HTML, and run the same image
extraction (`img src` / `img srcset` / `source srcset`) over it — reusing
the existing `saveAsset` / `processSrcset` helpers. `data:`/`blob:` URLs are
skipped, same as the main `img[src]` path.

No new dependencies; only `goquery`, `strings`, `url` (all already imported).

## Result

On the same site, downloaded images went from **4 → 52**. The remaining
references are pure-JS `data-*-img-path` assets that no static cloner can
resolve.

- `go vet ./pkg/crawler/` clean
- `go test ./pkg/crawler/` passes

Happy to add a focused test if you'd like — the logic lives inside
`quotesParse`, so it would need either a small geziyor fixture or extracting
the noscript walk into a tiny helper. Let me know your preference.
